### PR TITLE
GetThisAppFolderAsync method

### DIFF
--- a/srcs/Xamarin.OneDrive.Connector.Files/Folders/Client.cs
+++ b/srcs/Xamarin.OneDrive.Connector.Files/Folders/Client.cs
@@ -129,6 +129,23 @@ namespace Xamarin.OneDrive.Files
          }
          catch (Exception) { throw; }
       }
+      
+     public async Task<FileData>GetThisAppFolderAsync()
+     {
+         var httpMessage = await GetAsync("drive/special/approot:/");
+         if (!httpMessage.IsSuccessStatusCode)
+         { throw new Exception(await httpMessage.Content.ReadAsStringAsync()); }
+
+         // SERIALIZE AND STORE RESULT
+         var httpContent = await httpMessage.Content.ReadAsStreamAsync();
+         var serializer = new System.Runtime.Serialization.Json.DataContractJsonSerializer(typeof(FileData));
+         var httpResult = (FileData)serializer.ReadObject(httpContent);
+
+         // RESULT
+         if (httpResult.parentReference != null)
+         { httpResult.FilePath = httpResult.parentReference.FilePath; }
+         return httpResult;
+     }
 
    }
 }


### PR DESCRIPTION
OneDrive has special folder for app files:
https://docs.microsoft.com/en-us/onedrive/developer/rest-api/concepts/special-folders-appfolder?view=odsp-graph-online

So, adding method to get this folder can be useful shortcut. 

(It is a side-effect of trying to make 'CreateFolder' method :) )